### PR TITLE
Generate .cmxs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ include $(OCAMLDIR)/Makefile.config
 .PHONY: all
 all: $(ARCHIVE)
 .PHONY: allopt
-allopt:  $(XARCHIVE)
+allopt:  $(XARCHIVE) $(XSARCHIVE)
 
 depend: *.c *.ml *.mli
 	gcc -I $(OCAMLDIR) -MM *.c > depend
@@ -49,8 +49,8 @@ $(ARCHIVE): $(CARCHIVE) $(OBJECTS)
 $(XARCHIVE): $(CARCHIVE) $(XOBJECTS)
 	$(OCAMLMKLIB) -o $(NAME) $(XOBJECTS) -oc $(CARCHIVE_NAME) \
 	-L$(EXPAT_LIBDIR) $(EXPAT_LIB)
-$(XSARCHIVE): $(XARCHIVE)
-	$(OCAMLOPT) -linkall -shared -o $(XSARCHIVE) $(XARCHIVE) \
+$(XSARCHIVE): $(CARCHIVE) $(XOBJECTS)
+	$(OCAMLOPT) -linkall -shared -o $(XSARCHIVE) $(XOBJECTS) $(CARCHIVE) \
 	-ccopt -L$(EXPAT_LIBDIR) -cclib $(EXPAT_LIB)
 
 ## Installation

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ C_OBJECTS=expat_stubs$(EXT_OBJ)
 
 ARCHIVE=$(NAME).cma
 XARCHIVE=$(ARCHIVE:.cma=.cmxa)
+XSARCHIVE=$(ARCHIVE:.cma=.cmxs)
 CARCHIVE_NAME=mlexpat
 CARCHIVE=lib$(CARCHIVE_NAME)$(EXT_LIB)
 
@@ -48,11 +49,14 @@ $(ARCHIVE): $(CARCHIVE) $(OBJECTS)
 $(XARCHIVE): $(CARCHIVE) $(XOBJECTS)
 	$(OCAMLMKLIB) -o $(NAME) $(XOBJECTS) -oc $(CARCHIVE_NAME) \
 	-L$(EXPAT_LIBDIR) $(EXPAT_LIB)
+$(XSARCHIVE): $(XARCHIVE)
+	$(OCAMLOPT) -linkall -shared -o $(XSARCHIVE) $(XARCHIVE) \
+	-ccopt -L$(EXPAT_LIBDIR) -cclib $(EXPAT_LIB)
 
 ## Installation
 .PHONY: install
 install: all
-	{ test ! -f $(XARCHIVE) || extra="$(XARCHIVE) $(NAME)$(EXT_LIB)"; }; \
+	{ test ! -f $(XARCHIVE) || extra="$(XARCHIVE) $(XSARCHIVE) $(NAME)$(EXT_LIB)"; }; \
 	$(OCAMLFIND) install $(NAME) META $(NAME).cmi $(NAME).mli $(ARCHIVE) \
 	lib$(CARCHIVE_NAME)$(EXT_LIB) $$extra \
 	-optional dll$(CARCHIVE_NAME)$(EXT_DLL)

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,15 @@ OCAMLDOC=$(OCAMLFIND) ocamldoc $(OCAMLPKGS)
 OCAMLDIR=$(shell $(OCAMLFIND) query stdlib)
 include $(OCAMLDIR)/Makefile.config
 
+OPT_TARGETS=	$(XARCHIVE)
+ifeq ($(SUPPORTS_SHARED_LIBRARIES),true)
+OPT_TARGETS+=	$(XSARCHIVE)
+endif
+ 
 .PHONY: all
 all: $(ARCHIVE)
 .PHONY: allopt
-allopt:  $(XARCHIVE) $(XSARCHIVE)
+allopt:  $(OPT_TARGETS)
 
 depend: *.c *.ml *.mli
 	gcc -I $(OCAMLDIR) -MM *.c > depend
@@ -56,7 +61,7 @@ $(XSARCHIVE): $(CARCHIVE) $(XOBJECTS)
 ## Installation
 .PHONY: install
 install: all
-	{ test ! -f $(XARCHIVE) || extra="$(XARCHIVE) $(XSARCHIVE) $(NAME)$(EXT_LIB)"; }; \
+	{ test ! -f $(XARCHIVE) || extra="$(OPT_TARGETS) $(NAME)$(EXT_LIB)"; }; \
 	$(OCAMLFIND) install $(NAME) META $(NAME).cmi $(NAME).mli $(ARCHIVE) \
 	lib$(CARCHIVE_NAME)$(EXT_LIB) $$extra \
 	-optional dll$(CARCHIVE_NAME)$(EXT_DLL)


### PR DESCRIPTION
A patch (from the pkgsrc packaging system) that generates a .cmxs file for ocaml-expat. We've been using it for years, so it should be pretty well tested.